### PR TITLE
[feature/scrap-service] #49 찜꽁 가게 데이터 추가 저장에 따른 로직 변경

### DIFF
--- a/src/main/java/com/example/myongsick/domain/scrap/dto/CountResponse.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/dto/CountResponse.java
@@ -1,6 +1,13 @@
 package com.example.myongsick.domain.scrap.dto;
 
 public interface CountResponse {
-  String getStoreId();
+  Long getStoreId();
+  String getCode();
+  String getName();
+  String getCategory();
+  String getAddress();
+  String getContact();
+  String getUrlAddress();
+  String getDistance();
   int getScrapCount();
 }

--- a/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapCountResponse.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapCountResponse.java
@@ -13,12 +13,24 @@ import lombok.Setter;
 @AllArgsConstructor
 public class ScrapCountResponse {
 
-  private String storeId;
+  private Long storeId;
+  private String code;
+  private String name;
+  private String category;
+  private String address;
+  private String urlAddress;
+  private String distance;
   private int scrapCount;
 
   public static ScrapCountResponse toDto(CountResponse countResponse) {
     return ScrapCountResponse.builder()
         .storeId(countResponse.getStoreId())
+        .code(countResponse.getCode())
+        .name(countResponse.getName())
+        .category(countResponse.getCategory())
+        .address(countResponse.getAddress())
+        .urlAddress(countResponse.getUrlAddress())
+        .distance(countResponse.getDistance())
         .scrapCount(countResponse.getScrapCount())
         .build();
   }

--- a/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapRequest.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapRequest.java
@@ -12,7 +12,31 @@ public class ScrapRequest {
 
   @NotNull @NotBlank
   @ApiModelProperty(required = true, dataType = "String")
-  private String storeId;
+  private String code;
+
+  @NotNull @NotBlank
+  @ApiModelProperty(required = true, dataType = "String")
+  private String name;
+
+  @NotNull @NotBlank
+  @ApiModelProperty(required = true, dataType = "String")
+  private String distance;
+
+  @NotNull @NotBlank
+  @ApiModelProperty(required = true, dataType = "String")
+  private String category;
+
+  @NotNull @NotBlank
+  @ApiModelProperty(required = true, dataType = "String")
+  private String address;
+
+  @NotNull @NotBlank
+  @ApiModelProperty(required = true, dataType = "String")
+  private String contact;
+
+  @NotNull @NotBlank
+  @ApiModelProperty(required = true, dataType = "String")
+  private String urlAddress;
 
   @NotNull @NotBlank
   @ApiModelProperty(required = true, dataType = "String")

--- a/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapResponse.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapResponse.java
@@ -15,12 +15,24 @@ import lombok.NoArgsConstructor;
 public class ScrapResponse {
 
   private Long id;
-  private String storeId;
+  private String code;
+  private String name;
+  private String distance;
+  private String category;
+  private String address;
+  private String contact;
+  private String urlAddress;
 
   public static ScrapResponse toDto(Scrap scrap) {
     return ScrapResponse.builder()
         .id(scrap.getId())
-        .storeId(scrap.getStoreId())
+        .code(scrap.getStore().getCode())
+        .name(scrap.getStore().getName())
+        .distance(scrap.getStore().getDistance())
+        .category(scrap.getStore().getCategory())
+        .address(scrap.getStore().getAddress())
+        .contact(scrap.getStore().getContact())
+        .urlAddress(scrap.getStore().getUrlAddress())
         .build();
   }
 }

--- a/src/main/java/com/example/myongsick/domain/scrap/entity/Scrap.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/entity/Scrap.java
@@ -1,5 +1,7 @@
 package com.example.myongsick.domain.scrap.entity;
 
+import static javax.persistence.FetchType.LAZY;
+
 import com.example.myongsick.domain.food.entity.Week;
 import com.example.myongsick.domain.user.entity.User;
 import javax.persistence.Column;
@@ -24,20 +26,27 @@ public class Scrap {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  private String storeId;
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "id")
+  private Store store;
 
-  @ManyToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "user_id")
   private User user;
 
   @Builder
-  public Scrap(String storeId, User user) {
-    this.storeId = storeId;
+  public Scrap(Store store, User user) {
+    this.addStore(store);
     this.addUser(user);
   }
 
   public void addUser(User user){
     this.user = user;
     user.addScrap(this);
+  }
+
+  public void addStore(Store store) {
+    this.store = store;
+    store.addScrap(this);
   }
 }

--- a/src/main/java/com/example/myongsick/domain/scrap/entity/Store.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/entity/Store.java
@@ -1,0 +1,57 @@
+package com.example.myongsick.domain.scrap.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Store {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String code;
+  private String name;
+  private String distance;
+  private String category;
+  private String address;
+  private String contact;
+  private String urlAddress;
+
+  @OneToMany(mappedBy = "store", cascade = CascadeType.ALL)
+  List<Scrap> scrapList = new ArrayList<>();
+
+  @Builder
+  public Store(
+      String code,
+      String name,
+      String distance,
+      String category,
+      String address,
+      String contact,
+      String urlAddress) {
+    this.code = code;
+    this.name = name;
+    this.category = category;
+    this.distance = distance;
+    this.address = address;
+    this.contact = contact;
+    this.urlAddress = urlAddress;
+  }
+
+  public void addScrap(Scrap scrap) {
+    this.scrapList.add(scrap);
+  }
+}

--- a/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepository.java
@@ -3,6 +3,7 @@ package com.example.myongsick.domain.scrap.repository;
 import com.example.myongsick.domain.scrap.dto.CountResponse;
 import com.example.myongsick.domain.scrap.dto.ScrapCountResponse;
 import com.example.myongsick.domain.scrap.dto.ScrapResponse;
+import com.example.myongsick.domain.scrap.entity.Store;
 import com.example.myongsick.domain.user.entity.User;
 import com.example.myongsick.domain.scrap.entity.Scrap;
 import java.util.Optional;
@@ -14,10 +15,12 @@ import org.springframework.data.jpa.repository.Query;
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
   Page<Scrap> findAllByUser(User user, Pageable pageable);
 
-  Optional<Scrap> findByStoreId(String storeId);
+  Optional<Scrap> findByStoreAndUser(Store store, User user);
   @Query(nativeQuery = true,
-      value = "select store_id as storeId, count(store_id) as scrapCount from scrap group by store_id",
-      countQuery = "select count(store_id) as scrapCount from scrap "
+      value = "select a.id as storeId, b.code, b.name, b.category, b.address, b.contact, b.url_address, b.distance, count(a.id) as scrapCount\n"
+          + "from scrap a join store b on a.id = b.id\n"
+          + "group by a.id",
+      countQuery = "select count(id) as scrapCount from scrap "
   )
   Page<CountResponse> findAllCustom(Pageable pageable);
 }

--- a/src/main/java/com/example/myongsick/domain/scrap/repository/StoreRepository.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/repository/StoreRepository.java
@@ -1,0 +1,10 @@
+package com.example.myongsick.domain.scrap.repository;
+
+import com.example.myongsick.domain.scrap.entity.Store;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+  Optional<Store> findByCode(@Param("code") String code);
+}

--- a/src/main/java/com/example/myongsick/domain/scrap/service/ScrapServiceImpl.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/service/ScrapServiceImpl.java
@@ -4,13 +4,16 @@ import com.example.myongsick.domain.scrap.dto.ScrapCountResponse;
 import com.example.myongsick.domain.scrap.dto.ScrapRequest;
 import com.example.myongsick.domain.scrap.dto.ScrapResponse;
 import com.example.myongsick.domain.scrap.entity.Scrap;
+import com.example.myongsick.domain.scrap.entity.Store;
 import com.example.myongsick.domain.scrap.exception.AlreadyScrapException;
 import com.example.myongsick.domain.scrap.exception.NotFoundScrapException;
 import com.example.myongsick.domain.scrap.exception.ScrapException;
 import com.example.myongsick.domain.scrap.repository.ScrapRepository;
+import com.example.myongsick.domain.scrap.repository.StoreRepository;
 import com.example.myongsick.domain.user.entity.User;
 import com.example.myongsick.domain.user.exception.NotFoundUserException;
 import com.example.myongsick.domain.user.repository.UserRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ScrapServiceImpl implements ScrapService{
   private final UserRepository userRepository;
   private final ScrapRepository scrapRepository;
+  private final StoreRepository storeRepository;
   @Override
   public Page<ScrapResponse> getScrapList(String phoneId, Pageable pageable) {
     // 유저 조회
@@ -34,12 +38,24 @@ public class ScrapServiceImpl implements ScrapService{
   @Transactional
   public ScrapResponse createScrap(ScrapRequest request) {
     User user = userRepository.findByPhoneId(request.getPhoneId()).orElseThrow(NotFoundUserException::new);
-    if (scrapRepository.findByStoreId(request.getStoreId()).isPresent())
+    Store store = createStore(request);
+    if (scrapRepository.findByStoreAndUser(store, user).isPresent())
       throw new AlreadyScrapException();
-    Scrap scrap = scrapRepository.save(Scrap.builder().storeId(request.getStoreId()).user(user).build());
+    Scrap scrap = scrapRepository.save(Scrap.builder().store(store).user(user).build());
     return ScrapResponse.toDto(scrap);
   }
 
+  private Store createStore(ScrapRequest request) {
+    Optional<Store> already = storeRepository.findByCode(request.getCode());
+    if (already.isPresent())
+      return already.get();
+    else {
+      Store store = Store.builder().code(request.getCode()).name(request.getName())
+          .category(request.getCategory()).distance(request.getDistance()).address(request.getAddress())
+          .urlAddress(request.getUrlAddress()).contact(request.getContact()).build();
+    return storeRepository.save(store);
+    }
+  }
   @Override
   @Transactional
   public void deleteScrap(Long scrapId) {


### PR DESCRIPTION
### 주요 작업 내용
찜꽁리스트 구현에 사용 되는 가게 정보 추가 저장으로 인해 로직을 변경하였습니다. 

<br><br>
## 작업 내용 정리
- 가게 (Store) 테이블 분리
- 가게 DAO 생성
- 페이지네이션 구현을 위한 인터페이스 수정
- 페이지네이션 구현을 위한 네이티브 쿼리문 수정
- 찜꽁리스트 추가 시, "이미 찜꽁한 가게입니다." 오류 처리 수정
- 찜꽁리스트 추가 혹은 조회 시, 반환 데이터 수정

<br><br>
## 변경점
- 가게 테이블 분리

이유: 가게별로 고유의 데이터가 다수 존재함에 따라 테이블 분리 결정하였습니다.

- 찜꽁 테이블 pk 설정 ( 고유 ID 부여 )

이유 : 찜꽁 테이블( Scrap )에 FK 2개 ( user_id, store_id )로 PK 설정을 하는 것이 아닌 고유의 ID를 부여하여 PK로 설정하였습니다. 프론트로부터 PK 만 넘겨 받아도 위의 두 개의 값들이 고유함이 보장되고 넘겨 받는 데이터의 수가 더 적어서 이 방식으로 진행하였습니다.

- 페이지네이션 구현을 위한 네이티브 쿼리문 작성

이유: 가게별 유저가 담은 찜꽁 수를 페이지네이션에서 노출하기 위해서 네이티브 쿼리문을 작성하였습니다. 이를 위해 추가의 인터페이스 정의가 필요했습니다.

- 찜꽁 리스트 추가 시, "이미 찜꽁한 가게입니다." 오류 처리 수정

이유: 기존에는 store_id 값으로만 중복 체크를 진행했습니다. 다른 유저가 동일한 가게를 찜꽁리스트에 담으려 하면, 해당 오류가 발생함을 테스트 과정에서 발견해서 조건을 유저의 phone_id와 store_id 2개로 수정하였습니다.

- 찜꽁 리스트 조회 혹은 생성 시, 반환 데이터 수정

이유: 프론트엔드 측으로부터 데이터베이스에 저장되어야 하는 데이터가 추가되어야 함을 전달받아 요청/응답 DTO를 수정하였습니다.

