### PR TITLE
[infra/mongodb] 몽고디비 마이그레이션 로컬 환경 세팅 및 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.4'
 
+    // mongo
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
     implementation group: 'io.swagger.core.v3', name: 'swagger-annotations', version: '2.2.2'
     implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  mongodb:
+    image: mongo
+    container_name: mongo_test
+    ports:
+      - "27017:27017"

--- a/src/main/java/com/example/myongsick/domain/dish/controller/DishController.java
+++ b/src/main/java/com/example/myongsick/domain/dish/controller/DishController.java
@@ -1,0 +1,57 @@
+package com.example.myongsick.domain.dish.controller;
+
+import com.example.myongsick.domain.dish.dto.DishRequest;
+import com.example.myongsick.domain.dish.dto.DishResponse;
+import com.example.myongsick.domain.dish.service.DishService;
+import com.example.myongsick.domain.dish.dto.HateRequest;
+import com.example.myongsick.domain.dish.dto.LoveRequest;
+import com.example.myongsick.domain.dish.dto.RestaurantRequest;
+import com.example.myongsick.global.object.ApplicationResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v3/dish")
+public class DishController {
+
+  private final DishService dishService;
+
+  @GetMapping
+  public ApplicationResponse<List<DishResponse>> getDishAll() {
+    return ApplicationResponse.ok(dishService.getDishAll());
+  }
+
+  @PostMapping
+  public ApplicationResponse<String> createDish(
+      @RequestBody DishRequest request
+  ) {
+    return ApplicationResponse.ok(dishService.createDish(request));
+  }
+
+  @PostMapping("/restaurant")
+  public ApplicationResponse<String> createRestaurant(
+      @RequestBody RestaurantRequest request
+  ) {
+    return ApplicationResponse.ok(dishService.createRestaurant(request));
+  }
+
+  @PutMapping("/love")
+  public ApplicationResponse<Integer> calculateLoveCount(
+      @RequestBody LoveRequest request
+  ) {
+    return ApplicationResponse.ok(dishService.calculateLoveCount(request));
+  }
+  @PutMapping("/hate")
+  public ApplicationResponse<Integer> calculateHateCount(
+      @RequestBody HateRequest request
+  ) {
+    return ApplicationResponse.ok(dishService.calculateHateCount(request));
+  }
+}

--- a/src/main/java/com/example/myongsick/domain/dish/dto/DishRequest.java
+++ b/src/main/java/com/example/myongsick/domain/dish/dto/DishRequest.java
@@ -1,0 +1,14 @@
+package com.example.myongsick.domain.dish.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class DishRequest {
+  private LocalDate offeredAt;
+  private String mealType;
+  private String statusType;
+  private String restaurantId;
+  private List<String> menu;
+}

--- a/src/main/java/com/example/myongsick/domain/dish/dto/DishResponse.java
+++ b/src/main/java/com/example/myongsick/domain/dish/dto/DishResponse.java
@@ -1,0 +1,31 @@
+package com.example.myongsick.domain.dish.dto;
+
+import com.example.myongsick.domain.dish.entity.Dish;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DishResponse {
+  private String dishId;
+  private String toDay;
+  private String mealType;
+  private String statusType;
+  private List<String> menu;
+
+  public static DishResponse toDto(Dish dish) {
+    return DishResponse.builder()
+        .dishId(dish.get_id())
+        .toDay(dish.getOfferedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+        .mealType(dish.getMealType().name())
+        .statusType(dish.getStatusType().name())
+        .menu(dish.getMenus())
+        .build();
+  }
+}

--- a/src/main/java/com/example/myongsick/domain/dish/dto/HateRequest.java
+++ b/src/main/java/com/example/myongsick/domain/dish/dto/HateRequest.java
@@ -1,0 +1,10 @@
+package com.example.myongsick.domain.dish.dto;
+
+import lombok.Getter;
+
+@Getter
+public class HateRequest {
+
+  private String userId;
+  private String dishId;
+}

--- a/src/main/java/com/example/myongsick/domain/dish/dto/LoveRequest.java
+++ b/src/main/java/com/example/myongsick/domain/dish/dto/LoveRequest.java
@@ -1,0 +1,11 @@
+package com.example.myongsick.domain.dish.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoveRequest {
+
+  private String userId;
+  private String dishId;
+
+}

--- a/src/main/java/com/example/myongsick/domain/dish/dto/RestaurantRequest.java
+++ b/src/main/java/com/example/myongsick/domain/dish/dto/RestaurantRequest.java
@@ -1,0 +1,10 @@
+package com.example.myongsick.domain.dish.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RestaurantRequest {
+
+  private String name;
+  private String campusType;
+}

--- a/src/main/java/com/example/myongsick/domain/dish/entity/Dish.java
+++ b/src/main/java/com/example/myongsick/domain/dish/entity/Dish.java
@@ -1,0 +1,71 @@
+package com.example.myongsick.domain.dish.entity;
+
+import com.example.myongsick.domain.meal.entity.MealType;
+import com.example.myongsick.domain.meal.entity.StatusType;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.FieldType;
+
+@Getter
+@NoArgsConstructor
+@Document
+public class Dish {
+
+  @Id
+  @Field(value = "_id", targetType = FieldType.OBJECT_ID)
+  private String _id;
+
+  @Field("dish_type")
+  private MealType mealType;
+
+  @Field("status_type")
+  private StatusType statusType;
+
+  private List<String> menus;
+
+  @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+  private LocalDate offeredAt;
+
+  private Integer loveCount;
+  private Integer hateCount;
+
+  private String restaurantId;
+
+  @Builder
+  public Dish(
+      String mealType,
+      String statusType,
+      List<String> menus,
+      LocalDate offeredAt,
+      String restaurantId
+  ) {
+    this.mealType = MealType.valueOf(mealType);
+    this.statusType = StatusType.valueOf(statusType);
+    this.menus = menus;
+    this.offeredAt = offeredAt;
+    this.restaurantId = restaurantId;
+    this.loveCount= 0;
+    this.hateCount = 0;
+  }
+  public void addLoveCount() {
+    this.loveCount++;
+    System.out.println("loveCount ->>>>>> " + loveCount);
+  }
+  public void subLoveCount() {
+    this.loveCount--;
+  }
+  public void addHateCount() {
+    this.hateCount++;
+  }
+  public void subHateCount() {
+    this.hateCount--;
+  }
+}

--- a/src/main/java/com/example/myongsick/domain/dish/entity/Hate.java
+++ b/src/main/java/com/example/myongsick/domain/dish/entity/Hate.java
@@ -1,0 +1,31 @@
+package com.example.myongsick.domain.dish.entity;
+
+import lombok.Builder;
+import org.springframework.data.annotation.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.FieldType;
+
+@Getter
+@NoArgsConstructor
+@Document
+public class Hate {
+  @Id
+  @Field(value = "_id", targetType = FieldType.OBJECT_ID)
+  private String _id;
+
+  private String userId;
+
+  private String dishId;
+
+  @Builder
+  public Hate(
+      String userId,
+      String dishId
+  ) {
+    this.userId = userId;
+    this.dishId = dishId;
+  }
+}

--- a/src/main/java/com/example/myongsick/domain/dish/entity/Love.java
+++ b/src/main/java/com/example/myongsick/domain/dish/entity/Love.java
@@ -1,0 +1,32 @@
+package com.example.myongsick.domain.dish.entity;
+
+import org.springframework.data.annotation.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.FieldType;
+
+@Getter
+@NoArgsConstructor
+@Document
+public class Love {
+
+  @Id
+  @Field(value = "_id", targetType = FieldType.OBJECT_ID)
+  private String _id;
+
+  private String userId;
+
+  private String dishId;
+
+  @Builder
+  public Love(
+      String userId,
+      String dishId
+  ) {
+    this.userId = userId;
+    this.dishId = dishId;
+  }
+}

--- a/src/main/java/com/example/myongsick/domain/dish/entity/Restaurant.java
+++ b/src/main/java/com/example/myongsick/domain/dish/entity/Restaurant.java
@@ -1,0 +1,35 @@
+package com.example.myongsick.domain.dish.entity;
+
+import com.example.myongsick.domain.scrap.entity.CampusType;
+
+import org.springframework.data.annotation.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.FieldType;
+
+@Getter
+@NoArgsConstructor
+@Document
+public class Restaurant {
+
+  @Id
+  @Field(value = "_id", targetType = FieldType.OBJECT_ID)
+  private String _id;
+
+  @Field("name")
+  private String name;
+
+  private CampusType campusType;
+
+  @Builder
+  public Restaurant(
+      String name,
+      String campusType
+  ) {
+    this.name = name;
+    this.campusType = CampusType.valueOf(campusType);
+  }
+}

--- a/src/main/java/com/example/myongsick/domain/dish/repository/DishRepository.java
+++ b/src/main/java/com/example/myongsick/domain/dish/repository/DishRepository.java
@@ -1,0 +1,10 @@
+package com.example.myongsick.domain.dish.repository;
+
+import com.example.myongsick.domain.dish.entity.Dish;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DishRepository extends MongoRepository<Dish, String> {
+
+}

--- a/src/main/java/com/example/myongsick/domain/dish/repository/HateRepository.java
+++ b/src/main/java/com/example/myongsick/domain/dish/repository/HateRepository.java
@@ -1,0 +1,9 @@
+package com.example.myongsick.domain.dish.repository;
+
+import com.example.myongsick.domain.dish.entity.Hate;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface HateRepository extends MongoRepository<Hate, String> {
+  Boolean existsByDishIdAndUserId(String dishId, String userId);
+  void deleteByDishIdAndUserId(String dishId, String userId);
+}

--- a/src/main/java/com/example/myongsick/domain/dish/repository/LoveRepository.java
+++ b/src/main/java/com/example/myongsick/domain/dish/repository/LoveRepository.java
@@ -1,0 +1,9 @@
+package com.example.myongsick.domain.dish.repository;
+
+import com.example.myongsick.domain.dish.entity.Love;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface LoveRepository extends MongoRepository<Love, String> {
+  Boolean existsByDishIdAndUserId(String dishId, String userId);
+  void deleteByDishIdAndUserId(String dishId, String userId);
+}

--- a/src/main/java/com/example/myongsick/domain/dish/repository/RestaurantRepository.java
+++ b/src/main/java/com/example/myongsick/domain/dish/repository/RestaurantRepository.java
@@ -1,0 +1,8 @@
+package com.example.myongsick.domain.dish.repository;
+
+import com.example.myongsick.domain.dish.entity.Restaurant;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface RestaurantRepository extends MongoRepository<Restaurant, String> {
+
+}

--- a/src/main/java/com/example/myongsick/domain/dish/service/DishService.java
+++ b/src/main/java/com/example/myongsick/domain/dish/service/DishService.java
@@ -1,0 +1,80 @@
+package com.example.myongsick.domain.dish.service;
+
+import com.example.myongsick.domain.dish.repository.DishRepository;
+import com.example.myongsick.domain.dish.repository.HateRepository;
+import com.example.myongsick.domain.dish.repository.LoveRepository;
+import com.example.myongsick.domain.dish.repository.RestaurantRepository;
+import com.example.myongsick.domain.dish.dto.RestaurantRequest;
+import com.example.myongsick.domain.dish.dto.DishRequest;
+import com.example.myongsick.domain.dish.dto.DishResponse;
+import com.example.myongsick.domain.dish.dto.HateRequest;
+import com.example.myongsick.domain.dish.dto.LoveRequest;
+import com.example.myongsick.domain.dish.entity.Dish;
+import com.example.myongsick.domain.dish.entity.Hate;
+import com.example.myongsick.domain.dish.entity.Love;
+import com.example.myongsick.domain.dish.entity.Restaurant;
+import com.example.myongsick.domain.user.entity.User;
+import com.example.myongsick.domain.user.repository.UserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DishService {
+  private final DishRepository dishRepository;
+  private final RestaurantRepository restaurantRepository;
+  private final LoveRepository loveRepository;
+  private final HateRepository hateRepository;
+  private final UserRepository userRepository;
+
+  public List<DishResponse> getDishAll() {
+    return dishRepository.findAll().stream().map(DishResponse::toDto).collect(Collectors.toList());
+  }
+
+  @Transactional
+  public String createDish(DishRequest request) {
+    Restaurant findRestaurant = restaurantRepository.findById(request.getRestaurantId()).orElseThrow();
+    Dish saved = dishRepository.save(Dish.builder().offeredAt(request.getOfferedAt()).mealType(request.getMealType()).statusType(request.getStatusType()).menus(request.getMenu()).restaurantId(
+        findRestaurant.get_id()).build());
+    return saved.get_id();
+  }
+
+  @Transactional
+  public String createRestaurant(RestaurantRequest request) {
+    Restaurant saved = restaurantRepository.save(Restaurant.builder().name(request.getName()).campusType(request.getCampusType()).build());
+    return saved.get_id();
+  }
+
+  @Transactional
+  public Integer calculateLoveCount(LoveRequest request) {
+    Dish findDish = dishRepository.findById(request.getDishId()).orElseThrow();
+    User findUser = userRepository.findByPhoneId(request.getUserId()).orElseThrow();
+    if (!loveRepository.existsByDishIdAndUserId(findDish.get_id(), findUser.getPhoneId())) {
+      loveRepository.insert(Love.builder().dishId(findDish.get_id()).userId(findUser.getPhoneId()).build());
+      findDish.addLoveCount();
+    } else {
+      findDish.subLoveCount();
+      loveRepository.deleteByDishIdAndUserId(findDish.get_id(), findUser.getPhoneId());
+    }
+
+    return dishRepository.save(findDish).getLoveCount();
+  }
+
+  @Transactional
+  public Integer calculateHateCount(HateRequest request) {
+    Dish findDish = dishRepository.findById(request.getDishId()).orElseThrow();
+    User findUser = userRepository.findByPhoneId(request.getUserId()).orElseThrow();
+    if (!hateRepository.existsByDishIdAndUserId(findDish.get_id(), findUser.getPhoneId())) {
+      hateRepository.insert(Hate.builder().dishId(findDish.get_id()).userId(findUser.getPhoneId()).build());
+      findDish.addHateCount();
+    } else {
+      findDish.subHateCount();
+      hateRepository.deleteByDishIdAndUserId(findDish.get_id(), findUser.getPhoneId());
+    }
+
+    return dishRepository.save(findDish).getLoveCount();
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,9 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/mongo_test
 
 jasypt:
   encryptor:


### PR DESCRIPTION
### 주요 작업 내용
몽고디비로 로컬 환경 세팅을 하였습니다.

<br><br>
## 작업 내용 정리
- docker-compose 파일 작성 ( 도커 컨테이너로 몽고디비 사용 )
- application.yml 파일 수정 ( 몽고디비 사용을 위한 프로퍼티 적용 )
- Document 생성 ( 식사, 좋아요, 싫어요, 식당 )
- API 개발 ( Document 와 비즈니스 로직 동작 확인용 )

<br><br>
## 변경점
- docker-compose.yml 파일 작성

이유 : 로컬 환경에서 운영체제와 버전 등의 제약으로부터 벗어나 동일하게 작업을 할 수 있도록 도커 컨테이너로 몽고디비를 사용하였습니다. 해당 파일에는 몽고디비 구동을 위한 이미지 파일 정보만을 작성하였습니다.

- application.yml 파일 수정

이유 : 몽고디비 사용을 위한 프로퍼티를 추가하였습니다. 로컬 환경 테스트이기 때문에 암호화 처리는 하지 않았습니다.

- Document 생성

이유 : RDB와 몽고디비의 혼합 사용이 가능한지를 테스트하기 위해 Document를 생성해서 마이그레이션 작업을 일부 진행했습니다. 운영 환경에 영향이 가지 않도록 운영 RDB에서 조회하는 쿼리 외에는 비즈니스 로직에서 사용하지 않습니다.
마이그레이션 테스트를 위해 식사 테이블, 식당 테이블만을 Document로 적용하였습니다. 기존에 좋아요와 싫어요에 대해서는 속성값으로 두어 계산하였으나, 별도의 Document로 분리하여 유저 본인이 눌렀는지 아닌지에 대한 정보까지 서버에서 관리하는 식으로 구성하였습니다.

- API 개발

이유 : 실제로 비즈니스로직을 검증 및 네트워크 레이어에서 문제가 없음을 검증하기 위해 API를 개발하였으며, 이는 POSTMAN 도구를 이용해 검증하였습니다.  단순 테스트를 목적으로 진행한 작업이기 때문에 모든 API를 구현하지 않았습니다.

<br><br>
## 고민 Point

1. 스키마 디자인

스키마 디자인을 어떤 식으로 가져갈 지에 대해서는 혼자만의 결정이 아닌 팀원과의 합의가 이루어져야 하는 부분이기 때문에, 기존 구조와 유사하게 가져갔습니다.

2. MongoTemplate vs. MongoRepository 

스프링에서 몽고디비를 사용하기 위한 ORM에는 두 가지 방식이 있습니다. 두 방식의 장단점에 대해서는 [여기](https://ckddn9496.tistory.com/102)를 참고해주시기 바랍니다.

RDB와 연동하여 사용하면서 Repository 사용이 더 익숙하기 때문에 환경 세팅에서도 Repository를 이용하는 방식을 선택하였습니다. Template으로 세밀한 데이터 조작까지는 현재 기능에서 필요하지 않을 것이라고 판단한 것도 이유 중 하나입니다.

3. MongoDB로의 마이그레이션이 옳은 선택일까?

로컬 환경 세팅을 진행하면서 마이그레이션이 필수적인지에 대한 생각이 들었습니다. ( 저는 필수적이지 않다고 생각합니다. ) 
-> NoSQL의 대표적인 특징 중 하나인 "컬럼의 수평적 확장" 때문에 몽고디비를 시도해보려고 했었는데, 기존 테이블에서도 충분히 개선할 수 있는 방법이 떠올랐습니다.

[기존 방식]
Meal ( MealId, MealType, StatusType, Menu1, Menu2, Menu3, Menu4, Menu5, Menu6, OfferedAt, Love, Hate, WeekId, AreaId )

식단 테이블에서 식단을 구성하는 메뉴를 별도의 속성으로 두어 관리하였습니다. 이때의 문제점은 `null-safe` 하지 못하다는 것입니다. 
사전에 식단 정보가 입력되지 않은 채 조회하려고 하면, null 에 대한 처리가 menu1 ~ menu6 까지 6번 이루어져야 합니다. 

[개선 방안]
Converter를 이용해 `,`로 menu를 구분지어 리스트 형태로 하나의 컬럼에 메뉴를 저장합니다. ( 이 방식은 이미지 주소 값을 배열 형태로 저장하는 구성에서 착안하였습니다. ) 
클라이언트에게 반환하는 응답 데이터 형식 역시 List<String> 타입이라면, DB 에서도 List<String> 타입으로 저장하고 있어도 문제가 없을 것이라 생각합니다. 

4. 개발 중 마주한 이슈

고민 Point는 아니지만, RDB와 MongoDB를 혼합해서 사용하다보니, Document를 정의할 때 사소한 이슈가 있었습니다.
`@Id` 어노테이션의 import 오류로 인한 `save` 함수에서의 duplicate-key exception 발생입니다.
JPA를 사용하면서 `@Entity` 어노테이션을 이용하여 테이블을 정의할 때, `@Id` 어노테이션을 통해 PK임을 표시합니다. 이때의 import와 Document에서 사용하는 `@Id`의 import가 다릅니다. 이 점을 놓쳐서 _id 가 중복된다는 오류를 마주했습니다. 😅 

## 작업 순서

1. 해당 브랜치 pull 받기
2. [Terminal] 열기 -> `docker-compose up -d` 명령어 입력하기
3. 도커 컨테이너 구동 확인 후, 스프링 어플리케이션 실행하기
4. 아래 API로 요청 보내기
[식당 추가하기] POST
- URL

`localhost:8080/api/v3/dish/restaurant`
- DATA 

```` bash
{
    "name" : "MCC식당",
    "campusType" : "SEOUL"
}
````
[식단 추가하기] POST
- URL

`localhost:8080/api/v3/dish`
- DATA

```` bash
{
    "offeredAt": "2023-03-24",
    "mealType": "LUNCH_A",
    "statusType": "OPEN",
    "restaurantId" : "641d4125f1a1563e43ad3737", // 위에서 반환받은 식당ID 넣어주세요.
    "menu" : ["백미", "미역국", "제육볶음"]
}
````
[식단 조회하기] GET
- URL

`localhost:8080/api/v3/dish`

[좋아요] PUT
- URL

`localhost:8080/api/v3/dish/love`

- DATA

```` bash
{
    "userId" : "string", // 이건 그대로 사용하시면 됩니다. 테스트 계정이라서.
    "dishId" : "641d4132f1a1563e43ad3738" // 여기에 위에서 반환 받은 식단 ID 넣어주세요.
}
````