### PR TITLE
[fix/review-service] 리뷰 생성 시, 식당 데이터 받기

### DIFF
--- a/src/main/java/com/example/myongsick/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/myongsick/domain/review/controller/ReviewController.java
@@ -1,5 +1,6 @@
 package com.example.myongsick.domain.review.controller;
 
+import com.example.myongsick.domain.review.dto.ReviewReqDto;
 import com.example.myongsick.domain.review.dto.ReviewRequest;
 import com.example.myongsick.domain.review.dto.ReviewResponse;
 import com.example.myongsick.domain.review.service.ReviewService;
@@ -48,5 +49,17 @@ public class ReviewController {
       @RequestBody @Valid ReviewRequest request
   ){
     return ApplicationResponse.ok(reviewService.createReview(request));
+  }
+
+  @PostMapping("/area")
+  @ApiOperation(value = "리뷰 생성 with 식당명"
+      + " ( 리뷰 생성 시에는 user 등록이 선행되어야 합니다. "
+      + "writerId 에는 user 등록에 사용된 phoneId를 입력해주세요. )"
+      + " 리뷰를 작성하기 원하는 날짜 형식은 yyyy-MM-dd 입니다. "
+      + "areaName에는 디비와 동일한 식당명을 입력해주셔야 합니다.")
+  public ApplicationResponse<ReviewResponse> createReviewWithArea(
+      @RequestBody @Valid ReviewReqDto request
+  ){
+    return ApplicationResponse.ok(reviewService.createReviewWithArea(request));
   }
 }

--- a/src/main/java/com/example/myongsick/domain/review/dto/ReviewReqDto.java
+++ b/src/main/java/com/example/myongsick/domain/review/dto/ReviewReqDto.java
@@ -1,0 +1,11 @@
+package com.example.myongsick.domain.review.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ReviewReqDto {
+  private String writerId;
+  private String registeredAt;
+  private String content;
+  private String areaName;
+}

--- a/src/main/java/com/example/myongsick/domain/review/dto/ReviewRequest.java
+++ b/src/main/java/com/example/myongsick/domain/review/dto/ReviewRequest.java
@@ -3,7 +3,6 @@ package com.example.myongsick.domain.review.dto;
 import com.example.myongsick.domain.review.entity.Review;
 import com.example.myongsick.domain.user.entity.User;
 import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/myongsick/domain/review/entity/Review.java
+++ b/src/main/java/com/example/myongsick/domain/review/entity/Review.java
@@ -27,16 +27,23 @@ public class Review extends BaseEntity {
   private String registeredAt;
 
   private String content;
+  private String area;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
   private User user;
 
+
   @Builder
-  public Review(User user, String content, String registeredAt) {
+  public Review(
+      User user,
+      String content,
+      String registeredAt,
+      String area) {
     this.user = user;
     this.registeredAt = registeredAt;
     this.content = content;
+    this.area = area;
     this.addUser(user);
   }
 

--- a/src/main/java/com/example/myongsick/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/myongsick/domain/review/service/ReviewService.java
@@ -1,5 +1,6 @@
 package com.example.myongsick.domain.review.service;
 
+import com.example.myongsick.domain.review.dto.ReviewReqDto;
 import com.example.myongsick.domain.review.dto.ReviewRequest;
 import com.example.myongsick.domain.review.dto.ReviewResponse;
 import org.springframework.data.domain.Page;
@@ -12,4 +13,6 @@ public interface ReviewService {
   ReviewResponse getReview(Long reviewId);
 
   ReviewResponse createReview(ReviewRequest request);
+
+  ReviewResponse createReviewWithArea(ReviewReqDto request);
 }

--- a/src/main/java/com/example/myongsick/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/myongsick/domain/review/service/ReviewServiceImpl.java
@@ -1,5 +1,9 @@
 package com.example.myongsick.domain.review.service;
 
+import com.example.myongsick.domain.meal.entity.Area;
+import com.example.myongsick.domain.meal.exception.excute.NotFoundAreaException;
+import com.example.myongsick.domain.meal.repository.AreaRepository;
+import com.example.myongsick.domain.review.dto.ReviewReqDto;
 import com.example.myongsick.domain.review.dto.ReviewRequest;
 import com.example.myongsick.domain.review.dto.ReviewResponse;
 import com.example.myongsick.domain.review.entity.Review;
@@ -21,6 +25,7 @@ public class ReviewServiceImpl implements ReviewService{
 
   private final ReviewRepository reviewRepository;
   private final UserRepository userRepository;
+  private final AreaRepository areaRepository;
 
   @Override
   public Page<ReviewResponse> getReviewLists(Pageable pageable) {
@@ -39,6 +44,15 @@ public class ReviewServiceImpl implements ReviewService{
     User user = userRepository.findByPhoneId(request.getWriterId()).orElseThrow(
         NotFoundUserException::new);
     Review review = reviewRepository.save(request.toEntity(user, request.getRegisteredAt(), request.getContent()));
+    return ReviewResponse.toDto(review);
+  }
+
+  @Override
+  @Transactional
+  public ReviewResponse createReviewWithArea(ReviewReqDto request) {
+    User user = userRepository.findByPhoneId(request.getWriterId()).orElseThrow(NotFoundUserException::new);
+    Review review = reviewRepository.save(Review.builder().area(request.getAreaName()).user(user).content(
+        request.getContent()).registeredAt(request.getRegisteredAt()).build());
     return ReviewResponse.toDto(review);
   }
 }


### PR DESCRIPTION
### 주요 작업 내용
리뷰 테이블에 어느 식당에 대한 리뷰인지 파악하기 위해 식당명 데이터를 추가하였습니다.

<br><br>
## 작업 내용 정리
- Review Entity에 area_name 컬럼 추가하기 ( nullalbe )
- 식당 데이터 포함 리뷰 생성 API 기능 개발
- dev DB 서버에서 테스트 후, prod DB 서버에서 테스트

<br><br>
## 변경점
- Review Entity에 컬럼 추가하기

이유 : 사용자로부터 받는 데이터인 리뷰 데이터에는 **누가** **언제** **어떤 내용**의 리뷰를 작성 했는지에 대해서만 저장하고 있습니다. 좀 더 유의미한 인사이트를 도출하고자 어느 식당에 대한 리뷰인지를 파악하기 위해 리뷰 테이블에 식당 데이터를 추가하기로 하였습니다. ( 이는 PM으로부터의 요구사항이었습니다. ) 

[기존 테이블 구성]
REVIEW( ReviewID, Content, RegisteredAt, UserID )
AREA( AreaID, Name )

[변경된 테이블 구성]
REVIEW( ReviewID, Content, RegisteredAt, Area, UserID )
> 여기서 Area 는 Area 테이블이 아닌, 단순 식당명을 의미합니다.

식당 테이블이 존재함에도 불구하고 리뷰 테이블과 연관관계를 맺지 않은 이유는 "운영환경에서의 데이터 충돌" 때문입니다. 기존 리뷰 생성 API 에서는 식당명을 받지 않고 있으며, 운영 DB에서 리뷰와 식당 간의 연관관계가 없습니다. 따라서 연관관계를 추가할 경우, FK로 인한 식당 ID 값이 필수적이게 됩니다. 기존의 유저들이 남긴 리뷰 데이터에 대해서는 식당ID 가 null 이 되고, 새로운 리뷰에 대해서는 식당 데이터를 받고 있지 않았기 때문에 null로 인한 쿼리 오류가 발생하게 됩니다.

이러한 점 때문에 연관관계를 맺지 않고, 리뷰 테이블에 nullable 한 속성으로 식당명 컬럼을 추가하는 식으로 기능 구현을 하였습니다. 아래 사진은 변경된 테이블 구성을 보여줍니다.

<img width="1103" alt="image" src="https://user-images.githubusercontent.com/61505572/227726350-e8fc4662-f1a9-409a-bb75-1559b9c05c78.png">

- 식당 데이터 포함 리뷰 생성 API 기능 개발

이유 : 기존 리뷰 생성 API와 분리하여 개발하였습니다. 운영 중인 API와의 충돌을 피하고자 URL과 요청 DTO를 분리하여 기능 개발을 하였고, 이는 POSTMAN 도구를 통해 검증하였습니다. 

[기존 리뷰 생성 URL] `localhost:8080/api/v2/reviews`
[변경된 리뷰 생성 URL] `localhost:8080/api/v2/reviews/area`