### PR TITLE
[fix/scrap-service] 가게 목록 조회 시, 정렬 조건 추가

### DIFF
--- a/src/main/java/com/example/myongsick/domain/scrap/controller/ScarpController.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/controller/ScarpController.java
@@ -53,7 +53,11 @@ public class ScarpController {
   }
 
   @GetMapping("/store")
-  @ApiOperation(value = "가게별 담은 유저 수 조회")
+  @ApiOperation(value = "가게별 담은 유저 수 조회 \n"
+      + "[인기순|거리순] 에 대해 정렬을 지원합니다. \n"
+      + "인기순 -> api/v2/scraps/store?sort=scrapCount,desc&campus=YONGIN \n"
+      + "거리순 -> api/v2/scraps/store?sort=distance,asc&campus=YONGIN \n"
+      + "예시와 같이 요청을 보내주세요.")
   public ApplicationResponse<Page<ScrapCountResponse>> getScrapCount(
       @Param("campus") String campus,
       Pageable pageable

--- a/src/main/java/com/example/myongsick/domain/scrap/dto/CountResponse.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/dto/CountResponse.java
@@ -8,6 +8,6 @@ public interface CountResponse {
   String getAddress();
   String getContact();
   String getUrlAddress();
-  String getDistance();
+  Long getDistance();
   int getScrapCount();
 }

--- a/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapCountResponse.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapCountResponse.java
@@ -19,7 +19,7 @@ public class ScrapCountResponse {
   private String category;
   private String address;
   private String urlAddress;
-  private String distance;
+  private Long distance;
   private String contact;
   private int scrapCount;
 

--- a/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapRequest.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapRequest.java
@@ -19,8 +19,8 @@ public class ScrapRequest {
   private String name;
 
   @NotNull @NotBlank
-  @ApiModelProperty(required = true, dataType = "String")
-  private String distance;
+  @ApiModelProperty(required = true, dataType = "Long")
+  private Long distance;
 
   @NotNull @NotBlank
   @ApiModelProperty(required = true, dataType = "String")

--- a/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapResponse.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapResponse.java
@@ -17,7 +17,7 @@ public class ScrapResponse {
   private Long id;
   private String code;
   private String name;
-  private String distance;
+  private Long distance;
   private String category;
   private String address;
   private String contact;

--- a/src/main/java/com/example/myongsick/domain/scrap/entity/Store.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/entity/Store.java
@@ -26,7 +26,7 @@ public class Store {
 
   private String code;
   private String name;
-  private String distance;
+  private Long distance;
   private String category;
   private String address;
   private String contact;
@@ -41,7 +41,7 @@ public class Store {
   public Store(
       String code,
       String name,
-      String distance,
+      Long distance,
       String category,
       String address,
       String contact,

--- a/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepository.java
@@ -18,9 +18,13 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
   Optional<Scrap> findByStoreAndUser(Store store, User user);
   @Query(nativeQuery = true,
-      value = "select a.id as storeId, b.code, b.name, b.category, b.address, b.contact, b.url_address as urlAddress, b.distance, count(a.id) as scrapCount\n"
-          + "from scrap a join store b on a.id = b.id\n"
-          + "where b.campus = :campus\n"
+//      value = "select a.id as storeId, b.code, b.name, b.category, b.address, b.contact, b.url_address as urlAddress, b.distance, count(a.id) as scrapCount\n"
+//          + "from scrap a join store b on a.id = b.id\n"
+//          + "where b.campus = :campus\n"
+//          + "group by a.id",
+      value = "select a.id as storeId, a.code, a.name, a.category, a.address, a.contact, a.url_address as urlAddress, CAST(a.distance AS UNSIGNED) as distance, count(a.id) as scrapCount \n"
+          + "from store a join scrap b on a.id = b.id \n"
+          + "where a.campus = :campus \n"
           + "group by a.id",
       countQuery = "select count(id) as scrapCount from scrap "
   )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
### 주요 작업 내용
맛집 탭에서 가게 목록 조회 시, 정렬 조건에 "거리순" 추가하였습니다.

<br><br>
## 작업 내용 정리
- 가게 목록 조회 native query 수정

<br><br>
## 변경점
- 쿼리에서 테이블 조인 순서 변경

이유 : scrap 테이블을 기준으로 store 테이블을 조인했을 때, 정렬 조건에 해당하는 "거리순"인 distance 컬럼으로 order by 가 적용되지 않았습니다. 이에 조인 순서를 변경하였습니다.

```` bash
  Optional<Scrap> findByStoreAndUser(Store store, User user);
  @Query(nativeQuery = true,
//      value = "select a.id as storeId, b.code, b.name, b.category, b.address, b.contact, b.url_address as urlAddress, b.distance, count(a.id) as scrapCount\n"
//          + "from scrap a join store b on a.id = b.id\n"
//          + "where b.campus = :campus\n"
//          + "group by a.id",
      value = "select a.id as storeId, a.code, a.name, a.category, a.address, a.contact, a.url_address as urlAddress, CAST(a.distance AS UNSIGNED) as distance, count(a.id) as scrapCount \n"
          + "from store a join scrap b on a.id = b.id \n"
          + "where a.campus = :campus \n"
          + "group by a.id",
      countQuery = "select count(id) as scrapCount from scrap "
  )
  Page<CountResponse> findAllCustom(@Param("campus") String campus, Pageable pageable);
````

- 가게 테이블의 거리 컬럼 타입 캐스팅

이유 : 가게 테이블에는 거리(distance) 컬럼이 있습니다. 이는 기준점(명지대학교)로부터 가게가 얼마나 멀리 떨어져 있는가에 대한 수치적 데이터입니다. 거리의 제한이 어디까지인지 파악되지 않은 상태여서 해당 컬럼의 타입을 varchar(255)로 지정하였습니다.

이때의 문제점은 정렬조건으로써 "거리순"을 적용하였을 때, desc / asc가 정상적으로 동작하지 않는 점이었습니다.
이를 해결하고자 select 쿼리에서 distance 컬럼을 Integer 타입으로 캐스팅하였습니다.

- Swagger에서 Pageable 객체 사용으로 인한 오류 수정

이유 : Controller에서 파라미터로 넘겨받는 Pageable 인터페이스와 구현체의 property 이름이 서로 달라서 오류가 발생합니다. 이를 해결하기 위해 SwaggerConfig 파일에서 페이징을 위한 설정을 추가하였습니다.