### PR TITLE
[feature/store-service] 가게 테이블에 위도와 경도 컬럼 추가에 따른 코드 수정

### DIFF
--- a/.github/workflows/CI_Dev.yml
+++ b/.github/workflows/CI_Dev.yml
@@ -54,10 +54,23 @@ jobs:
     # (5) 테스트
     - name: Test with Gradle
       run: ./gradlew --info test
- 
+
+      # (7) 상테 확인
+    - name: Save sate
+      run: echo "{name}={value}" >> $GITHUB_STATE
+
+    - name: Set output
+      run : echo "{name}={value}" >> $GITHUB_OUTPUT
+
     # (6) 테스트 후 결과 파일 생성
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1
       if: ${{ always() }}  # 테스트가 실패하여도 Report를 보기 위해 `always`로 설정
       with:
         files: build/test-results/**/*.xml
+    # (7) 상테 확인
+    - name: Save sate
+      run: echo "{name}={value}" >> $GITHUB_STATE
+
+    - name: Set output
+      run : echo "{name}={value}" >> $GITHUB_OUTPUT

--- a/src/main/java/com/example/myongsick/domain/scrap/dto/CountResponse.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/dto/CountResponse.java
@@ -10,4 +10,6 @@ public interface CountResponse {
   String getUrlAddress();
   String getDistance();
   int getScrapCount();
+  Double getLatitude();
+  Double getLongitude();
 }

--- a/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapCountResponse.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapCountResponse.java
@@ -21,6 +21,8 @@ public class ScrapCountResponse {
   private String urlAddress;
   private String distance;
   private String contact;
+  private Double latitude;
+  private Double longitude;
   private int scrapCount;
 
   public static ScrapCountResponse toDto(CountResponse countResponse) {
@@ -34,6 +36,8 @@ public class ScrapCountResponse {
         .distance(countResponse.getDistance())
         .scrapCount(countResponse.getScrapCount())
         .contact(countResponse.getContact())
+        .latitude(countResponse.getLatitude())
+        .longitude(countResponse.getLongitude())
         .build();
   }
 }

--- a/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapRequest.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapRequest.java
@@ -45,4 +45,7 @@ public class ScrapRequest {
   @NotNull @NotBlank
   @ApiModelProperty(required = true, dataType = "String")
   private String campus;
+
+  private Double latitude;
+  private Double longitude;
 }

--- a/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapResponse.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapResponse.java
@@ -22,6 +22,8 @@ public class ScrapResponse {
   private String address;
   private String contact;
   private String urlAddress;
+  private Double latitude;
+  private Double longitude;
 
   public static ScrapResponse toDto(Scrap scrap) {
     return ScrapResponse.builder()
@@ -33,6 +35,8 @@ public class ScrapResponse {
         .address(scrap.getStore().getAddress())
         .contact(scrap.getStore().getContact())
         .urlAddress(scrap.getStore().getUrlAddress())
+        .latitude(scrap.getStore().getLatitude())
+        .longitude(scrap.getStore().getLongitude())
         .build();
   }
 }

--- a/src/main/java/com/example/myongsick/domain/scrap/entity/Store.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/entity/Store.java
@@ -34,6 +34,9 @@ public class Store {
   @Enumerated(EnumType.STRING)
   private CampusType campus;
 
+  private Double latitude;
+  private Double longitude;
+
   @OneToMany(mappedBy = "store", cascade = CascadeType.ALL)
   List<Scrap> scrapList = new ArrayList<>();
 
@@ -46,7 +49,9 @@ public class Store {
       String address,
       String contact,
       String urlAddress,
-      CampusType campus) {
+      CampusType campus,
+      Double latitude,
+      Double longitude) {
     this.code = code;
     this.name = name;
     this.category = category;
@@ -55,6 +60,8 @@ public class Store {
     this.contact = contact;
     this.urlAddress = urlAddress;
     this.campus = campus;
+    this.latitude = latitude;
+    this.longitude = longitude;
   }
 
   public void addScrap(Scrap scrap) {

--- a/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepository.java
@@ -22,7 +22,7 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 //          + "from scrap a join store b on a.id = b.id\n"
 //          + "where b.campus = :campus\n"
 //          + "group by a.id",
-      value = "select a.id as storeId, a.code, a.name, a.category, a.address, a.contact, a.url_address as urlAddress, CAST(a.distance AS UNSIGNED) as distance, count(a.id) as scrapCount \n"
+      value = "select a.id as storeId, a.code, a.name, a.category, a.address, a.contact, a.url_address as urlAddress, CAST(a.distance AS UNSIGNED) as distance, count(a.id) as scrapCount, a.latitude, a.longitude \n"
           + "from store a join scrap b on a.id = b.id \n"
           + "where a.campus = :campus \n"
           + "group by a.id",

--- a/src/main/java/com/example/myongsick/domain/scrap/service/ScrapServiceImpl.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/service/ScrapServiceImpl.java
@@ -52,7 +52,8 @@ public class ScrapServiceImpl implements ScrapService{
     else {
       Store store = Store.builder().code(request.getCode()).name(request.getName())
           .category(request.getCategory()).distance(request.getDistance()).address(request.getAddress())
-          .urlAddress(request.getUrlAddress()).contact(request.getContact()).campus(CampusType.valueOf(request.getCampus())).build();
+          .urlAddress(request.getUrlAddress()).contact(request.getContact()).campus(CampusType.valueOf(request.getCampus()))
+          .latitude(request.getLatitude()).longitude(request.getLongitude()).build();
     return storeRepository.save(store);
     }
   }


### PR DESCRIPTION
### 주요 작업 내용
가게 테이블에 위도와 경도 컬럼 추가 하였습니다.

<br><br>
## 작업 내용 정리
- 위도와 경도 컬럼 추가
- 컬럼 추가에 따른 DTO 수정
- 컬럼 추가에 따른 Repository에서 native query 문 수정

<br><br>
## 변경점
- 가게 테이블에 위도와 경도 컬럼 추가

이유 : 프론트엔드 측의 요청으로 수행한 작업입니다. 위도와 경도 데이터는 Double 타입으로 지정하였으며, Null을 허용합니다.
운영 환경에서 ddl-auto를 `none` 으로 두고 사용 중이기 때문에, dev DB 서버로 테스트를 진행하였습니다.

로컬 환경에서 아래 포스트맨 화면과 같이 수행 됨을 확인하였습니다.
<img width="701" alt="image" src="https://user-images.githubusercontent.com/61505572/229992663-feaa8a54-3ecb-46a1-84da-fbea3436eb2f.png">

dev DB 서버 기준 store 테이블의 DDL은 아래와 같습니다.
<img width="383" alt="image" src="https://user-images.githubusercontent.com/61505572/229992808-49e35523-4180-43cd-ad62-366031125e2b.png">

