### PR TITLE
[refactor/store-service] review, scrap, user 패키지 내 코드 정리

### DIFF
--- a/src/main/java/com/example/myongsick/domain/review/dto/ReviewRequest.java
+++ b/src/main/java/com/example/myongsick/domain/review/dto/ReviewRequest.java
@@ -17,17 +17,14 @@ import lombok.NoArgsConstructor;
 @ApiModel(description = "리뷰 생성을 위한 객체")
 public class ReviewRequest {
 
-//  @ApiModelProperty(value = "유저 핸드폰 ID", required = true, dataType = "String")
   @NotNull(message = "유저 핸드폰 ID를 입력해주세요")
   @NotBlank(message = "유저 핸드폰 ID를 입력해주세요")
   private String writerId;
 
-//  @ApiModelProperty(value = "리뷰 날짜", required = true, dataType = "String")
   @NotNull(message = "리뷰를 남길 날짜를 입력해주세요")
   @NotBlank(message = "리뷰를 남길 날짜를 입력해주세요")
   private String registeredAt;
 
-//  @ApiModelProperty(value = "식사 리뷰", required = true, dataType = "String")
   @NotNull(message = "식사에 대한 리뷰를 입력해주세요")
   @NotBlank(message = "식사에 대한 리뷰를 입력해주세요")
   private String content;

--- a/src/main/java/com/example/myongsick/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/myongsick/domain/review/service/ReviewServiceImpl.java
@@ -1,8 +1,5 @@
 package com.example.myongsick.domain.review.service;
 
-import com.example.myongsick.domain.meal.entity.Area;
-import com.example.myongsick.domain.meal.exception.excute.NotFoundAreaException;
-import com.example.myongsick.domain.meal.repository.AreaRepository;
 import com.example.myongsick.domain.review.dto.ReviewReqDto;
 import com.example.myongsick.domain.review.dto.ReviewRequest;
 import com.example.myongsick.domain.review.dto.ReviewResponse;
@@ -25,7 +22,6 @@ public class ReviewServiceImpl implements ReviewService{
 
   private final ReviewRepository reviewRepository;
   private final UserRepository userRepository;
-  private final AreaRepository areaRepository;
 
   @Override
   public Page<ReviewResponse> getReviewLists(Pageable pageable) {
@@ -41,8 +37,7 @@ public class ReviewServiceImpl implements ReviewService{
   @Override
   @Transactional
   public ReviewResponse createReview(ReviewRequest request) {
-    User user = userRepository.findByPhoneId(request.getWriterId()).orElseThrow(
-        NotFoundUserException::new);
+    User user = userRepository.findByPhoneId(request.getWriterId()).orElseThrow(NotFoundUserException::new);
     Review review = reviewRepository.save(request.toEntity(user, request.getRegisteredAt(), request.getContent()));
     return ReviewResponse.toDto(review);
   }
@@ -51,8 +46,7 @@ public class ReviewServiceImpl implements ReviewService{
   @Transactional
   public ReviewResponse createReviewWithArea(ReviewReqDto request) {
     User user = userRepository.findByPhoneId(request.getWriterId()).orElseThrow(NotFoundUserException::new);
-    Review review = reviewRepository.save(Review.builder().area(request.getAreaName()).user(user).content(
-        request.getContent()).registeredAt(request.getRegisteredAt()).build());
+    Review review = reviewRepository.save(Review.builder().area(request.getAreaName()).user(user).content(request.getContent()).registeredAt(request.getRegisteredAt()).build());
     return ReviewResponse.toDto(review);
   }
 }

--- a/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapCountResponse.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapCountResponse.java
@@ -1,5 +1,6 @@
 package com.example.myongsick.domain.scrap.dto;
 
+import io.swagger.annotations.ApiModel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +12,7 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@ApiModel(description = "찜꽁 리스트 응답 객체 ( + 찜꽁수 포함 )")
 public class ScrapCountResponse {
 
   private Long storeId;

--- a/src/main/java/com/example/myongsick/domain/scrap/entity/Scrap.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/entity/Scrap.java
@@ -2,11 +2,9 @@ package com.example.myongsick.domain.scrap.entity;
 
 import static javax.persistence.FetchType.LAZY;
 
-import com.example.myongsick.domain.food.entity.Week;
 import com.example.myongsick.domain.user.entity.User;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;

--- a/src/main/java/com/example/myongsick/domain/scrap/entity/Store.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/entity/Store.java
@@ -1,10 +1,8 @@
 package com.example.myongsick.domain.scrap.entity;
 
-import com.google.gson.JsonElement;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;

--- a/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepository.java
@@ -1,11 +1,9 @@
 package com.example.myongsick.domain.scrap.repository;
 
 import com.example.myongsick.domain.scrap.dto.CountResponse;
-import com.example.myongsick.domain.scrap.dto.ScrapCountResponse;
-import com.example.myongsick.domain.scrap.dto.ScrapResponse;
+import com.example.myongsick.domain.scrap.entity.Scrap;
 import com.example.myongsick.domain.scrap.entity.Store;
 import com.example.myongsick.domain.user.entity.User;
-import com.example.myongsick.domain.scrap.entity.Scrap;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,10 +16,6 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
   Optional<Scrap> findByStoreAndUser(Store store, User user);
   @Query(nativeQuery = true,
-//      value = "select a.id as storeId, b.code, b.name, b.category, b.address, b.contact, b.url_address as urlAddress, b.distance, count(a.id) as scrapCount\n"
-//          + "from scrap a join store b on a.id = b.id\n"
-//          + "where b.campus = :campus\n"
-//          + "group by a.id",
       value = "select a.id as storeId, a.code, a.name, a.category, a.address, a.contact, a.url_address as urlAddress, CAST(a.distance AS UNSIGNED) as distance, count(a.id) as scrapCount, a.latitude, a.longitude \n"
           + "from store a join scrap b on a.id = b.id \n"
           + "where a.campus = :campus \n"

--- a/src/main/java/com/example/myongsick/domain/scrap/repository/StoreRepository.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/repository/StoreRepository.java
@@ -2,6 +2,7 @@ package com.example.myongsick.domain.scrap.repository;
 
 import com.example.myongsick.domain.scrap.dto.CountResponse;
 import com.example.myongsick.domain.scrap.entity.Store;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,6 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
           + "group by a.id"
   )
   Optional<CountResponse> findByIdCustom(Long storeId);
+
+  List<Store> findAllByLatitudeIsNull();
 }

--- a/src/main/java/com/example/myongsick/domain/scrap/service/ScrapServiceImpl.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/service/ScrapServiceImpl.java
@@ -20,10 +20,7 @@ import com.google.gson.JsonParser;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.ProtocolException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.List;
@@ -44,11 +41,10 @@ public class ScrapServiceImpl implements ScrapService{
   private final StoreRepository storeRepository;
 
   @Value("${kakao.rest-key}")
-  private String key;
+  private String kakaoRestKey;
 
   @Override
   public Page<ScrapResponse> getScrapList(String phoneId, Pageable pageable) {
-    // 유저 조회
     User user = userRepository.findByPhoneId(phoneId).orElseThrow(NotFoundUserException::new);
     return scrapRepository.findAllByUser(user, pageable).map(ScrapResponse::toDto);
   }
@@ -58,16 +54,14 @@ public class ScrapServiceImpl implements ScrapService{
   public ScrapResponse createScrap(ScrapRequest request) {
     User user = userRepository.findByPhoneId(request.getPhoneId()).orElseThrow(NotFoundUserException::new);
     Store store = createStore(request);
-    if (scrapRepository.findByStoreAndUser(store, user).isPresent())
-      throw new AlreadyScrapException();
+    if (scrapRepository.findByStoreAndUser(store, user).isPresent()) throw new AlreadyScrapException();
     Scrap scrap = scrapRepository.save(Scrap.builder().store(store).user(user).build());
     return ScrapResponse.toDto(scrap);
   }
 
   private Store createStore(ScrapRequest request) {
     Optional<Store> already = storeRepository.findByCode(request.getCode());
-    if (already.isPresent())
-      return already.get();
+    if (already.isPresent()) return already.get();
     else {
       Store store = Store.builder().code(request.getCode()).name(request.getName())
           .category(request.getCategory()).distance(request.getDistance()).address(request.getAddress())
@@ -91,34 +85,26 @@ public class ScrapServiceImpl implements ScrapService{
 
   @Transactional
   public void updateStore() {
-    List<Store> storeList = storeRepository.findAll();
-    String pass = "";
-    for (int i =0; i < storeList.size(); i++) {
-     try {
-        pass = URLEncoder.encode(storeList.get(i).getName(), "UTF-8");
-      } catch (UnsupportedEncodingException e) {
-        throw new RuntimeException(e);
-      }
-      String host = storeList.get(i).getCampus() == CampusType.YONGIN ? "https://dapi.kakao.com/v2/local/search/keyword?query=" + pass + "&category_group_code=FD6%2C%20CE7&x=127.18758354347&y=37.224650469991&radius=3000&page=2&size=15&sort=distance" : "https://dapi.kakao.com/v2/local/search/keyword?query=" + pass + "&category_group_code=FD6%2C%20CE7&x=126.923460283882&y=37.5803504797164&radius=3000&page=2&size=15&sort=distance";
+    List<Store> storeList = storeRepository.findAllByLatitudeIsNull();
+    for (Store store : storeList) {
       try {
+        String pass = URLEncoder.encode(store.getName(), "UTF-8");
+        String host = store.getCampus() == CampusType.YONGIN ? "https://dapi.kakao.com/v2/local/search/keyword?query=" + pass + "&category_group_code=FD6%2C%20CE7&x=127.18758354347&y=37.224650469991&radius=3000&page=2&size=15&sort=distance" : "https://dapi.kakao.com/v2/local/search/keyword?query=" + pass + "&category_group_code=FD6%2C%20CE7&x=126.923460283882&y=37.5803504797164&radius=3000&page=2&size=15&sort=distance";
         URL url = new URL(host);
         HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
-        urlConnection.setRequestProperty("Authorization", " KakaoAK " + key);
+        urlConnection.setRequestProperty("Authorization", " KakaoAK " + kakaoRestKey);
         urlConnection.setRequestMethod("GET");
         BufferedReader br = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
-        String line = "";
-        String result = "";
-        while ((line = br.readLine()) != null) {result += line;}
-        JsonObject jobj = (JsonObject) JsonParser.parseString(result);
-        JsonElement element = jobj.get("documents");
+        String line = "", result = "";
+        while ((line = br.readLine()) != null) {
+          result += line;
+        }
+        JsonObject jsonObj = (JsonObject) JsonParser.parseString(result);
+        JsonElement element = jsonObj.get("documents");
         JsonElement x = element.getAsJsonArray().get(0).getAsJsonObject().get("x");
         JsonElement y = element.getAsJsonArray().get(0).getAsJsonObject().get("y");
-        storeList.get(i).updatePoint(x.getAsString(), y.getAsString());
+        store.updatePoint(x.getAsString(), y.getAsString());
         br.close();
-      } catch (MalformedURLException e) {
-        throw new RuntimeException(e);
-      } catch (ProtocolException e) {
-        throw new RuntimeException(e);
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
@@ -128,6 +114,5 @@ public class ScrapServiceImpl implements ScrapService{
   @Override
   public ScrapCountResponse getStoreOne(Long storeId) {
     return storeRepository.findByIdCustom(storeId).map(ScrapCountResponse::toDto).orElseThrow(NotFoundStoreException::new);
-
   }
 }

--- a/src/main/java/com/example/myongsick/domain/user/dto/UserRequest.java
+++ b/src/main/java/com/example/myongsick/domain/user/dto/UserRequest.java
@@ -1,6 +1,5 @@
 package com.example.myongsick.domain.user.dto;
 
-import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
@@ -11,8 +10,6 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class UserRequest {
-//  @ApiModelProperty(required = true, dataType = "String")
-  @NotNull
-  @NotBlank
+  @NotNull @NotBlank
   private String phoneId;
 }

--- a/src/main/java/com/example/myongsick/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/example/myongsick/domain/user/dto/UserResponse.java
@@ -3,7 +3,6 @@ package com.example.myongsick.domain.user.dto;
 import com.example.myongsick.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/example/myongsick/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/myongsick/domain/user/service/UserServiceImpl.java
@@ -18,8 +18,7 @@ public class UserServiceImpl implements UserService{
   @Override
   @Transactional
   public UserResponse createUser(UserRequest request) {
-    if (userRepository.findByPhoneId(request.getPhoneId()).isPresent())
-      throw new AlreadyUserException();
+    if (userRepository.findByPhoneId(request.getPhoneId()).isPresent()) throw new AlreadyUserException();
     User user = userRepository.save(User.builder().phoneId(request.getPhoneId()).build());
     return UserResponse.toDto(user);
   }


### PR DESCRIPTION
### 주요 작업 내용
review, scrap, user 패키지 내 코드 정리

<br><br>
## 작업 내용 정리
- 불필요한 import 문 제거
- 공백 및 코드 라인 수 줄이기
- 카카오맵 API와 통신 로직 일부 수정

<br><br>
## 변경점
- 카카오맵 API 통신으로 위도 경도 값 채우는 로직 수정에서 모든 가게 데이터 조회에서 위도 null 인 데이터 조회로 변경

이유 : 위도 경도 값이 null 인 데이터에 대해서만 업데이트 쿼리를 실행하면 되기 때문에 select 조회 조건을 수정하였습니다.
처음 로직 작성 시, null 조건을 걸지 않았던 이유는 개발 당시 모든 가게 데이터가 위도와 경도 값이 null이었기 때문이었으며 해당 API를 일회성으로 사용하고 삭제할 예정이었기 때문입니다. 프론트엔드 측 업데이트가 진행되지 않은 상태에서 유저가 새로운 가게에 대해 찜꽁을 누르면, 해당 가게의 위도와 경도 데이터가 null 인 채로 운영 디비에 반영되기 때문에 API 호출이 몇 번 더 있을 것으로 판단해서 로직을 수정하였습니다.

