### PR TITLE
[feature/scrap-service] native query를 querydsl로 변경

### DIFF
--- a/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapCountResponse.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/dto/ScrapCountResponse.java
@@ -1,17 +1,14 @@
 package com.example.myongsick.domain.scrap.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.annotations.ApiModel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor
-@AllArgsConstructor
 @ApiModel(description = "찜꽁 리스트 응답 객체 ( + 찜꽁수 포함 )")
 public class ScrapCountResponse {
 
@@ -20,12 +17,28 @@ public class ScrapCountResponse {
   private String name;
   private String category;
   private String address;
+  private String contact;
   private String urlAddress;
   private String distance;
-  private String contact;
   private String latitude;
   private String longitude;
   private int scrapCount;
+  @QueryProjection
+  public ScrapCountResponse(Long storeId, String code, String name, String category, String address,
+      String contact, String urlAddress, String distance, String latitude, String longitude,
+      int scrapCount) {
+    this.storeId = storeId;
+    this.code = code;
+    this.name = name;
+    this.category = category;
+    this.address = address;
+    this.contact = contact;
+    this.urlAddress = urlAddress;
+    this.distance = distance;
+    this.latitude = latitude;
+    this.longitude = longitude;
+    this.scrapCount = scrapCount;
+  }
 
   public static ScrapCountResponse toDto(CountResponse countResponse) {
     return ScrapCountResponse.builder()

--- a/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepositoryCustom.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.example.myongsick.domain.scrap.repository;
+
+import com.example.myongsick.domain.scrap.dto.ScrapCountResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
+
+public interface ScrapRepositoryCustom {
+  Page<ScrapCountResponse> findAllByCampusWithPaging(@Param("campus") String campus, Pageable pageable);
+}

--- a/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepositoryCustom.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.example.myongsick.domain.scrap.repository;
 
 import com.example.myongsick.domain.scrap.dto.ScrapCountResponse;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
@@ -8,5 +9,5 @@ import org.springframework.data.repository.query.Param;
 public interface ScrapRepositoryCustom {
   Page<ScrapCountResponse> findAllByCampusWithPaging(@Param("campus") String campus, Pageable pageable);
 
-  ScrapCountResponse findByIdCustom(Long storeId);
+  Optional<ScrapCountResponse> findByIdCustom(Long storeId);
 }

--- a/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepositoryCustom.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepositoryCustom.java
@@ -7,4 +7,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface ScrapRepositoryCustom {
   Page<ScrapCountResponse> findAllByCampusWithPaging(@Param("campus") String campus, Pageable pageable);
+
+  ScrapCountResponse findByIdCustom(Long storeId);
 }

--- a/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepositoryImpl.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepositoryImpl.java
@@ -44,6 +44,14 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom{
     return new PageImpl<>(result, pageable, count);
   }
 
+  @Override
+  public ScrapCountResponse findByIdCustom(Long storeId) {
+    return jpaQueryFactory.select(new QScrapCountResponse(store.id.as("storeId"), store.code, store.name, store.category, store.address, store.contact, store.urlAddress, store.distance, store.latitude, store.longitude, store.scrapList.size().as("scrapCount")))
+        .from(store)
+        .where(store.id.eq(storeId))
+        .fetchOne();
+  }
+
   private List<OrderSpecifier> getOrderSpecifier(Sort sort) {
     List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
     sort.stream()

--- a/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepositoryImpl.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepositoryImpl.java
@@ -1,0 +1,64 @@
+package com.example.myongsick.domain.scrap.repository;
+
+import static com.example.myongsick.domain.scrap.entity.QScrap.scrap;
+import static com.example.myongsick.domain.scrap.entity.QStore.store;
+
+import com.example.myongsick.domain.scrap.dto.QScrapCountResponse;
+import com.example.myongsick.domain.scrap.dto.ScrapCountResponse;
+import com.example.myongsick.domain.scrap.entity.CampusType;
+import com.example.myongsick.domain.scrap.entity.Store;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ScrapRepositoryImpl implements ScrapRepositoryCustom{
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public Page<ScrapCountResponse> findAllByCampusWithPaging(String campus, Pageable pageable) {
+    List<ScrapCountResponse> result =  jpaQueryFactory.select(new QScrapCountResponse(store.id.as("storeId"), store.code, store.name, store.category, store.address, store.contact, store.urlAddress, store.distance, store.latitude, store.longitude, store.scrapList.size().as("scrapCount")))
+        .from(store)
+        .where(store.campus.eq(CampusType.valueOf(campus)))
+        .groupBy(store.code)
+        .orderBy(getOrderSpecifier(pageable.getSort()).stream().toArray(OrderSpecifier[]::new))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    Long count = jpaQueryFactory
+        .select(scrap.count())
+        .from(scrap)
+        .fetchOne();
+
+    return new PageImpl<>(result, pageable, count);
+  }
+
+  private List<OrderSpecifier> getOrderSpecifier(Sort sort) {
+    List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+    sort.stream()
+        .forEach(order -> {
+          Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+          String property = order.getProperty();
+          if(property.equals("scrapCount")) {
+            orderSpecifiers.add(new OrderSpecifier(direction, store.scrapList.size()));
+          } else if(property.equals("distance")) {
+            orderSpecifiers.add(new OrderSpecifier(direction, store.distance.castToNum(Long.class)));
+          } else {
+            PathBuilder orderByExpression = new PathBuilder(Store.class, "store");
+            orderSpecifiers.add(new OrderSpecifier(direction, orderByExpression.get(property)));
+          }
+          });
+    return orderSpecifiers;
+  }
+}

--- a/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepositoryImpl.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/repository/ScrapRepositoryImpl.java
@@ -13,6 +13,7 @@ import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -45,11 +46,11 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom{
   }
 
   @Override
-  public ScrapCountResponse findByIdCustom(Long storeId) {
-    return jpaQueryFactory.select(new QScrapCountResponse(store.id.as("storeId"), store.code, store.name, store.category, store.address, store.contact, store.urlAddress, store.distance, store.latitude, store.longitude, store.scrapList.size().as("scrapCount")))
+  public Optional<ScrapCountResponse> findByIdCustom(Long storeId) {
+    return Optional.ofNullable(jpaQueryFactory.select(new QScrapCountResponse(store.id.as("storeId"), store.code, store.name, store.category, store.address, store.contact, store.urlAddress, store.distance, store.latitude, store.longitude, store.scrapList.size().as("scrapCount")))
         .from(store)
         .where(store.id.eq(storeId))
-        .fetchOne();
+        .fetchOne());
   }
 
   private List<OrderSpecifier> getOrderSpecifier(Sort sort) {

--- a/src/main/java/com/example/myongsick/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/service/ScrapService.java
@@ -3,7 +3,6 @@ package com.example.myongsick.domain.scrap.service;
 import com.example.myongsick.domain.scrap.dto.ScrapCountResponse;
 import com.example.myongsick.domain.scrap.dto.ScrapRequest;
 import com.example.myongsick.domain.scrap.dto.ScrapResponse;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/src/main/java/com/example/myongsick/domain/scrap/service/ScrapServiceImpl.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/service/ScrapServiceImpl.java
@@ -10,6 +10,7 @@ import com.example.myongsick.domain.scrap.exception.AlreadyScrapException;
 import com.example.myongsick.domain.scrap.exception.NotFoundScrapException;
 import com.example.myongsick.domain.scrap.exception.NotFoundStoreException;
 import com.example.myongsick.domain.scrap.repository.ScrapRepository;
+import com.example.myongsick.domain.scrap.repository.ScrapRepositoryCustom;
 import com.example.myongsick.domain.scrap.repository.StoreRepository;
 import com.example.myongsick.domain.user.entity.User;
 import com.example.myongsick.domain.user.exception.NotFoundUserException;
@@ -39,6 +40,7 @@ public class ScrapServiceImpl implements ScrapService{
   private final UserRepository userRepository;
   private final ScrapRepository scrapRepository;
   private final StoreRepository storeRepository;
+  private final ScrapRepositoryCustom scrapRepositoryCustom;
 
   @Value("${kakao.rest-key}")
   private String kakaoRestKey;
@@ -80,7 +82,8 @@ public class ScrapServiceImpl implements ScrapService{
 
   @Override
   public Page<ScrapCountResponse> getScrapCount(String campus, Pageable pageable) {
-    return scrapRepository.findAllCustom(campus, pageable).map(ScrapCountResponse::toDto);
+//    return scrapRepositoryCustom.findAllCustom(campus, pageable).map(ScrapCountResponse::toDto);
+    return scrapRepositoryCustom.findAllByCampusWithPaging(campus, pageable);
   }
 
   @Transactional

--- a/src/main/java/com/example/myongsick/domain/scrap/service/ScrapServiceImpl.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/service/ScrapServiceImpl.java
@@ -116,6 +116,11 @@ public class ScrapServiceImpl implements ScrapService{
 
   @Override
   public ScrapCountResponse getStoreOne(Long storeId) {
-    return storeRepository.findByIdCustom(storeId).map(ScrapCountResponse::toDto).orElseThrow(NotFoundStoreException::new);
+//    return storeRepository.findByIdCustom(storeId).map(ScrapCountResponse::toDto).orElseThrow(NotFoundStoreException::new);
+    ScrapCountResponse scrapCountResponse = scrapRepositoryCustom.findByIdCustom(storeId);
+    if( scrapCountResponse == null ) {
+      throw new NotFoundStoreException();
+    }
+    return scrapCountResponse;
   }
 }

--- a/src/main/java/com/example/myongsick/domain/scrap/service/ScrapServiceImpl.java
+++ b/src/main/java/com/example/myongsick/domain/scrap/service/ScrapServiceImpl.java
@@ -117,10 +117,6 @@ public class ScrapServiceImpl implements ScrapService{
   @Override
   public ScrapCountResponse getStoreOne(Long storeId) {
 //    return storeRepository.findByIdCustom(storeId).map(ScrapCountResponse::toDto).orElseThrow(NotFoundStoreException::new);
-    ScrapCountResponse scrapCountResponse = scrapRepositoryCustom.findByIdCustom(storeId);
-    if( scrapCountResponse == null ) {
-      throw new NotFoundStoreException();
-    }
-    return scrapCountResponse;
+    return scrapRepositoryCustom.findByIdCustom(storeId).orElseThrow(NotFoundStoreException::new);
   }
 }

--- a/src/main/java/com/example/myongsick/global/config/QueryDslConfig.java
+++ b/src/main/java/com/example/myongsick/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.example.myongsick.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+  @PersistenceContext
+  private EntityManager em;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+    return new JPAQueryFactory(em);
+  }
+}


### PR DESCRIPTION
### 주요 작업 내용
native query를 querydsl로 변경

<br><br>
## 작업 내용 정리
- native query를 querydsl로 변경

<br><br>
## 변경점
- QuerydslConfig 파일 생성

이유 : EntityManager 사용을 위해서 해당 설정 파일을 추가했습니다.

- 맛집 조회 탭에서 가게 데이터 조회 시 ( 페이징처리 포함 ) native 쿼리에서 동적 쿼리로 변경

- 가게 데이터 단일 조회 시, native 쿼리에서 동적 쿼리로 변경

이유 : 조인에 대한 N+1문제와 불필요한 DB 접근이 발생할 수 있기에 접근을 줄이고자 변경하였습니다.

- 응답 데이터 DTO에 @QueryProjection 어노테이션 추가

이유 : Q객체로 생성하기 위해 해당 어노테이션을 추가했습니다.

- 동적 정렬을 위한 멤버 함수 생성

이유 : 인기순, 거리순에 따른 정렬이 가능하도록 OrderSpecifier를 커스터마이징하였습니다.

## Notice

- 코드 작성하면서 마주했던 이슈

1. count() 집계 함수의 사용

native query 기반으로 코드를 작성했을 때, store.id.count() 로 하면 집계가 되지 않았습니다. 이 부분은 store.scrapList.size()로 수정하니 제가 원하던 값으로 출력 됨을 확인했습니다.

🙋🏻 질문!! 왜 store.id.count()로 하면 집계가 안될까요..? ( 집계함수를 사용했을 때에는 join을 걸었습니다! )

QueryDsl 사용이 처음이어서 적극적인 피드백 ( 코드리뷰 ) 환영입니다..!😊